### PR TITLE
Add Vitest setup and sample Footer test

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "dev": "vite",
     "build": "npm run lint && vite build",
     "lint": "eslint .",
-    "lint:error": "eslint . --quiet", 
-    "preview": "vite preview"
+    "lint:error": "eslint . --quiet",
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@questlabs/react-sdk": "^2.2.4",
@@ -32,6 +33,9 @@
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^1.5.0",
+    "jsdom": "^24.0.0",
+    "@testing-library/react": "^14.0.0"
   }
 }

--- a/src/components/Footer.test.jsx
+++ b/src/components/Footer.test.jsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import Footer from './Footer.jsx';
+
+describe('Footer component', () => {
+  it('renders company name', () => {
+    render(<Footer />);
+    expect(screen.getByText('TicketWayz')).toBeTruthy();
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,8 +10,11 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src')
     }
   },
-   build: {
+  build: {
     outDir: 'dist',
     sourcemap: true
   },
+  test: {
+    environment: 'jsdom'
+  }
 });


### PR DESCRIPTION
## Summary
- add Vitest and testing libraries
- configure Vite for testing
- add example Footer component test

## Testing
- `npm test` (fails: vitest: not found)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68954d1205a483228edbdd8c05934e69