### PR TITLE
feat: add styled pdf ticket generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "react-icons": "^5.4.0",
     "echarts": "^5.5.0",
     "echarts-for-react": "^3.0.2",
-    "date-fns": "4.1.0"
+    "date-fns": "4.1.0",
+    "pdf-lib": "^1.17.1",
+    "qrcode": "^1.5.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",


### PR DESCRIPTION
## Summary
- overhaul ticket PDF generator to use pdf-lib with color schemes, logos, and QR codes
- wire up layout settings and richer ticket content
- add pdf-lib and qrcode dependencies

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899ebbea2848322a1e71bb7c6700b1b