### PR TITLE
feat: expand ticket template styling options

### DIFF
--- a/src/components/admin/TicketLayoutSettings.jsx
+++ b/src/components/admin/TicketLayoutSettings.jsx
@@ -1,11 +1,118 @@
 import React from 'react';
 import TicketPreview from './TicketPreview';
 
-const TicketLayoutSettings = ({ settings, onDownloadPreview, onRefreshPreview, ticketData }) => {
+const TicketLayoutSettings = ({
+  settings,
+  onChange,
+  onDownloadPreview,
+  onRefreshPreview,
+  ticketData,
+}) => {
+  const handle = (section, field) => (e) => {
+    const value = e.target.type === 'checkbox' ? e.target.checked : e.target.value;
+    onChange((prev) => ({
+      ...prev,
+      [section]: {
+        ...prev[section],
+        [field]: value,
+      },
+    }));
+  };
+
   return (
     <div className="space-y-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 bg-zinc-100 dark:bg-zinc-800 p-4 rounded-lg">
+        <div className="flex flex-col">
+          <label className="text-sm mb-1 text-zinc-700 dark:text-zinc-300">Brand</label>
+          <input
+            type="text"
+            className="rounded border border-zinc-300 dark:border-zinc-600 bg-white dark:bg-zinc-700 px-2 py-1"
+            value={settings.companyInfo.brand || ''}
+            onChange={handle('companyInfo', 'brand')}
+          />
+        </div>
+
+        <div className="flex flex-col">
+          <label className="text-sm mb-1 text-zinc-700 dark:text-zinc-300">Accent</label>
+          <input
+            type="color"
+            className="h-10 w-full rounded border border-zinc-300 dark:border-zinc-600 bg-white dark:bg-zinc-700"
+            value={settings.design.accent || '#f59e0b'}
+            onChange={handle('design', 'accent')}
+          />
+        </div>
+
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            className="rounded border-zinc-300 dark:border-zinc-600"
+            checked={settings.design.darkHeader}
+            onChange={handle('design', 'darkHeader')}
+          />
+          <span className="text-sm text-zinc-700 dark:text-zinc-300">Dark header</span>
+        </label>
+
+        <div className="flex flex-col">
+          <label className="text-sm mb-1 text-zinc-700 dark:text-zinc-300">Rounded (px)</label>
+          <input
+            type="number"
+            min="0"
+            className="rounded border border-zinc-300 dark:border-zinc-600 bg-white dark:bg-zinc-700 px-2 py-1"
+            value={settings.design.rounded ?? 24}
+            onChange={handle('design', 'rounded')}
+          />
+        </div>
+
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            className="rounded border-zinc-300 dark:border-zinc-600"
+            checked={settings.design.shadow}
+            onChange={handle('design', 'shadow')}
+          />
+          <span className="text-sm text-zinc-700 dark:text-zinc-300">Shadow</span>
+        </label>
+
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            className="rounded border-zinc-300 dark:border-zinc-600"
+            checked={settings.ticketContent.showPrice}
+            onChange={handle('ticketContent', 'showPrice')}
+          />
+          <span className="text-sm text-zinc-700 dark:text-zinc-300">Show price</span>
+        </label>
+
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            className="rounded border-zinc-300 dark:border-zinc-600"
+            checked={settings.design.showQRCode}
+            onChange={handle('design', 'showQRCode')}
+          />
+          <span className="text-sm text-zinc-700 dark:text-zinc-300">Show QR</span>
+        </label>
+
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            className="rounded border-zinc-300 dark:border-zinc-600"
+            checked={settings.ticketContent.showTerms}
+            onChange={handle('ticketContent', 'showTerms')}
+          />
+          <span className="text-sm text-zinc-700 dark:text-zinc-300">Show terms</span>
+        </label>
+      </div>
+
       <TicketPreview
         settings={settings}
+        accent={settings.design.accent}
+        darkHeader={settings.design.darkHeader}
+        radius={settings.design.rounded}
+        shadow={settings.design.shadow}
+        showPrice={settings.ticketContent.showPrice}
+        showQr={settings.design.showQRCode}
+        showTerms={settings.ticketContent.showTerms}
         onDownload={onDownloadPreview}
         onRefresh={onRefreshPreview}
         ticketData={ticketData}

--- a/src/components/admin/TicketTemplateSettings.jsx
+++ b/src/components/admin/TicketTemplateSettings.jsx
@@ -65,7 +65,7 @@ const TicketTemplateSettings = () => {
     colorScheme: {
       primary: '#FCD34D', // Yellow
       secondary: '#1F2937', // Dark gray
-      accent: '#10B981', // Green
+      accent: '#f59e0b',
       background: '#FFFFFF',
       text: '#000000'
     },
@@ -77,6 +77,7 @@ const TicketTemplateSettings = () => {
       includeOrderInfo: true
     },
     companyInfo: {
+      brand: 'TicketWayz',
       name: 'TicketWayz',
       address: '',
       phone: '',
@@ -88,6 +89,7 @@ const TicketTemplateSettings = () => {
       showVenueInfo: true,
       showDateTime: true,
       showPrice: true,
+      showTerms: true,
       customInstructions: '',
       termsAndConditions: '',
       additionalFields: []
@@ -100,9 +102,9 @@ const TicketTemplateSettings = () => {
       layout: 'vertical', // vertical, horizontal
       heroUrl: '',
       darkHeader: false,
-      rounded: 12,
+      rounded: 24,
       shadow: true,
-      accent: '#10B981'
+      accent: '#f59e0b'
     }
   });
 
@@ -203,7 +205,7 @@ const TicketTemplateSettings = () => {
       colors: {
         primary: '#FCD34D',
         secondary: '#1F2937',
-        accent: '#10B981',
+        accent: '#f59e0b',
         background: '#FFFFFF',
         text: '#000000'
       }
@@ -233,7 +235,7 @@ const TicketTemplateSettings = () => {
       colors: {
         primary: '#FCD34D',
         secondary: '#374151',
-        accent: '#10B981',
+        accent: '#f59e0b',
         background: '#111827',
         text: '#FFFFFF'
       }
@@ -269,7 +271,16 @@ const TicketTemplateSettings = () => {
         const savedEmail = localStorage.getItem('emailSettings');
         
         if (savedTemplate) {
-          setTemplateSettings(prev => ({ ...prev, ...JSON.parse(savedTemplate) }));
+          const parsed = JSON.parse(savedTemplate);
+          setTemplateSettings(prev => ({
+            ...prev,
+            ...parsed,
+            colorScheme: { ...prev.colorScheme, ...parsed.colorScheme },
+            qrCode: { ...prev.qrCode, ...parsed.qrCode },
+            companyInfo: { ...prev.companyInfo, ...parsed.companyInfo },
+            ticketContent: { ...prev.ticketContent, ...parsed.ticketContent },
+            design: { ...prev.design, ...parsed.design },
+          }));
         }
         
         if (savedSMTP) {
@@ -409,7 +420,7 @@ const TicketTemplateSettings = () => {
         colorScheme: {
           primary: '#FCD34D',
           secondary: '#1F2937',
-          accent: '#10B981',
+          accent: '#f59e0b',
           background: '#FFFFFF',
           text: '#000000'
         },
@@ -421,6 +432,7 @@ const TicketTemplateSettings = () => {
           includeOrderInfo: true
         },
         companyInfo: {
+          brand: 'TicketWayz',
           name: 'TicketWayz',
           address: '',
           phone: '',
@@ -432,6 +444,7 @@ const TicketTemplateSettings = () => {
           showVenueInfo: true,
           showDateTime: true,
           showPrice: true,
+          showTerms: true,
           customInstructions: '',
           termsAndConditions: '',
           additionalFields: []
@@ -444,9 +457,9 @@ const TicketTemplateSettings = () => {
           layout: 'vertical',
           heroUrl: '',
           darkHeader: false,
-          rounded: 12,
+          rounded: 24,
           shadow: true,
-          accent: '#10B981'
+          accent: '#f59e0b'
         }
       });
       
@@ -611,6 +624,7 @@ const TicketTemplateSettings = () => {
       {activeTab === 'layout' && (
         <TicketLayoutSettings
           settings={templateSettings}
+          onChange={setTemplateSettings}
           onDownloadPreview={handleDownloadPreview}
           onRefreshPreview={handleRefreshPreview}
           ticketData={previewTicketData}


### PR DESCRIPTION
## Summary
- add layout controls for brand, accent color, header style, rounded corners, shadow and visibility toggles
- persist new template settings and propagate them to preview and PDF generation
- adjust default accent color and radius

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c902f27b48322b2fc216e804e9361