### PR TITLE
Use environment variables for Supabase configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+VITE_SUPABASE_URL="https://your-project.supabase.co"
+VITE_SUPABASE_ANON_KEY="public-anon-key"
+

--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ This project uses [Vite](https://vitejs.dev/) for development and the built-in N
    ```bash
    npm install
    ```
-3. Create an `.env.local` file in the project root with your Supabase credentials:
+3. Copy `.env.example` to `.env.local` and set your Supabase credentials:
    ```bash
-   SUPABASE_URL="https://your-project.supabase.co"
-   SUPABASE_ANON_KEY="public-anon-key"
+   cp .env.example .env.local
+   # then edit .env.local
+   VITE_SUPABASE_URL="https://your-project.supabase.co"
+   VITE_SUPABASE_ANON_KEY="public-anon-key"
    ```
 
 ## Supabase CLI

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,12 +1,12 @@
-import { createClient } from '@supabase/supabase-js'
+import { createClient } from '@supabase/supabase-js';
 
 // Project ID is auto-injected during deployment
-const SUPABASE_URL='https://nxbhaykrrvhrqbpzcyxh.supabase.co'
-const SUPABASE_ANON_KEY='eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im54YmhheWtycnZocnFicHpjeXhoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTMwMjMwNjQsImV4cCI6MjA2ODU5OTA2NH0.PETm29XpfgmnekbmiYnmY-3SlFzchIV9tofDH6bNPLg'
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 export default createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
   auth: {
     persistSession: true,
-    autoRefreshToken: true
-  }
-})
+    autoRefreshToken: true,
+  },
+});


### PR DESCRIPTION
## Summary
- Replace hard-coded Supabase URL and key with `import.meta.env` in Supabase client
- Add `.env.example` and update README instructions for Vite variables

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ca511f0108322a085cdbcbe3dea6e