### PR TITLE
Preserve event images in ticket flow

### DIFF
--- a/src/components/ticket/TicketTemplate.jsx
+++ b/src/components/ticket/TicketTemplate.jsx
@@ -126,6 +126,7 @@ const TicketTemplate = forwardRef(({ data = {}, options = {} }, ref) => {
               src={heroImage}
               alt=""
               className="absolute inset-0 h-full w-full object-cover opacity-80"
+              crossOrigin="anonymous"
             />
           )}
           <div className="absolute inset-0 bg-gradient-to-b from-black/60 via-black/20 to-transparent" />

--- a/src/pages/CheckoutPage.jsx
+++ b/src/pages/CheckoutPage.jsx
@@ -359,7 +359,7 @@ const CheckoutPage=()=> {
             row_number: seat.row_number,
             seat_number: seat.seat_number
           })),
-          event: eventDetails,
+          event: { ...eventDetails, image: eventDetails?.image },
           totalPrice: calculateTotal(),
           orderNumber: `TW-${order.id.substring(0,6)}`,
           customerInfo: {
@@ -403,7 +403,7 @@ const CheckoutPage=()=> {
             row_number: seat.row_number,
             seat_number: seat.seat_number
           })),
-          event: eventDetails,
+          event: { ...eventDetails, image: eventDetails?.image },
           totalPrice: calculateTotal(),
           orderNumber: `TW-${order.id.substring(0,6)}`,
           paymentMethod: 'Apple Pay',

--- a/src/pages/ThankYouPage.jsx
+++ b/src/pages/ThankYouPage.jsx
@@ -63,6 +63,10 @@ const ThankYouPage = () => {
     if (orderSummary) {
       const orderData = {
         ...orderSummary,
+        event: {
+          ...orderSummary.event,
+          image: orderSummary.event?.image,
+        },
         seats: orderSummary.seats?.map(seat => ({
           ...seat,
           section: seat.section,

--- a/src/pages/VenuePage.jsx
+++ b/src/pages/VenuePage.jsx
@@ -437,7 +437,8 @@ sessionStorage.setItem('selectedSeats',JSON.stringify(seatsForCheckout));
   date: event.event_date,
   location: event.location,
   venue: venue?.name,
-  note: event.note
+  note: event.note,
+  image: event.image
 }));
 
 navigate('/checkout');

--- a/src/utils/ticketExport/index.js
+++ b/src/utils/ticketExport/index.js
@@ -30,6 +30,7 @@ export function buildTermsText(order = {}, settings = {}) {
 export function validateImageUrl(url) {
   if (!url) return null;
   if (url.startsWith('data:image')) return url;
+  if (url.startsWith('/')) return new URL(url, window.location.origin).href;
   try {
     const { protocol } = new URL(url);
     if (protocol === 'http:' || protocol === 'https:') return url;


### PR DESCRIPTION
## Summary
- Store event image in session eventDetails
- Keep event image in order summary during checkout and download
- Allow relative image URLs and enable cross-origin hero images

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689de2e0136c8322a496222e73a09756