### PR TITLE
Use Vite URL for Roboto font in PDF template

### DIFF
--- a/src/components/ticket/TicketTemplatePDF.jsx
+++ b/src/components/ticket/TicketTemplatePDF.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import { Page, View, Text, Image, StyleSheet, Font } from '@react-pdf/renderer';
 import { CARD_WIDTH, HEADER_HEIGHT, sanitizeTicket } from './TicketTemplate';
-import RobotoRegular from '@/assets/fonts/Roboto-Regular.ttf';
 
-Font.register({ family: 'Roboto', src: RobotoRegular });
+Font.register({
+  family: 'Roboto',
+  src: new URL('../../assets/fonts/Roboto-Regular.ttf', import.meta.url).href,
+  format: 'truetype',
+});
 
 const styles = StyleSheet.create({
   page: {


### PR DESCRIPTION
## Summary
- load the Roboto font in `TicketTemplatePDF.jsx` via a Vite-friendly `new URL` reference

## Testing
- `npm test`
- `npm run build`
- `npx vite build --assetsInlineLimit 0`
- `curl -I http://localhost:4173/assets/Roboto-Regular-B_SY1GJM.ttf`


------
https://chatgpt.com/codex/tasks/task_e_689e3796885883228706b2b22ae9c8d8