### PR TITLE
fix: sanitize seat field in ticket rendering

### DIFF
--- a/src/components/ticket/TicketTemplate.jsx
+++ b/src/components/ticket/TicketTemplate.jsx
@@ -26,7 +26,12 @@ export function sanitizeTicket(data = {}) {
   ];
   const result = {};
   for (const key of fields) {
-    const val = data[key];
+    let val = data[key];
+    if (key === 'seat' && val && typeof val === 'object') {
+      val = [val.seat_number, val.label, val.number, val.id].find(
+        (v) => v !== undefined && v !== null,
+      );
+    }
     if (val !== undefined && val !== null) result[key] = toStr(val);
   }
   return result;

--- a/src/components/ticket/TicketTemplate.test.js
+++ b/src/components/ticket/TicketTemplate.test.js
@@ -36,3 +36,10 @@ test('sanitizeTicket stringifies ticketId', async () => {
   const { sanitizeTicket } = await loadSanitizeTicket();
   assert.equal(sanitizeTicket({ ticketId: 456 }).ticketId, '456');
 });
+
+test('sanitizeTicket extracts seat identifiers', async () => {
+  const { sanitizeTicket } = await loadSanitizeTicket();
+  assert.equal(sanitizeTicket({ seat: { seat_number: 7 } }).seat, '7');
+  assert.equal(sanitizeTicket({ seat: { label: 'VIP' } }).seat, 'VIP');
+  assert.equal(sanitizeTicket({ seat: {} }).seat, undefined);
+});


### PR DESCRIPTION
## Summary
- sanitize TicketTemplate props to convert seat objects to string identifiers
- test sanitizeTicket for seat object handling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e436b40ac8322afb5710d811758ef