### PR TITLE
Use URL-based Roboto font registration in PDF template

### DIFF
--- a/src/components/ticket/TicketTemplatePDF.jsx
+++ b/src/components/ticket/TicketTemplatePDF.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Page, View, Text, Image, StyleSheet, Font } from '@react-pdf/renderer';
 import { CARD_WIDTH, HEADER_HEIGHT, sanitizeTicket } from './TicketTemplate';
-import RobotoTtf from '@/assets/fonts/Roboto-Regular.ttf';
 
-Font.register({ family: 'Roboto', src: RobotoTtf, format: 'truetype' });
+const robotoTtf = new URL('../../assets/fonts/Roboto-Regular.ttf', import.meta.url).href;
+Font.register({ family: 'Roboto', src: robotoTtf, format: 'truetype' });
 
 const styles = StyleSheet.create({
   page: {


### PR DESCRIPTION
## Summary
- Load Roboto font in the PDF template using `new URL(..., import.meta.url)` and register it with `Font.register`

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/date-fns)*
- `npm run build` *(fails: Cannot find package '@eslint/js' due to failed dependency installation)*

------
https://chatgpt.com/codex/tasks/task_e_689e4ad54b3c8322a99f9f28fa0ee47d