### PR TITLE
feat: skip zone ticket generation when single seats exist

### DIFF
--- a/database-setup.sql
+++ b/database-setup.sql
@@ -82,6 +82,7 @@ DECLARE
   v_tickets_created INTEGER := 0;
   v_seats_created INTEGER := 0;
   v_zones_created INTEGER := 0;
+  v_has_single_seats BOOLEAN;
   v_result JSON;
 BEGIN
   -- Получаем venue_id для события
@@ -99,21 +100,27 @@ BEGIN
   -- Удаляем только свободные и удержанные билеты
   DELETE FROM tickets WHERE event_id = p_event_id AND status IN ('free', 'held');
 
-  -- Создаем билеты для зон (sections/polygons)
-  FOR v_zone_record IN 
-    SELECT id, capacity FROM zones WHERE venue_id = v_venue_id AND capacity > 0
-  LOOP
-    -- Создаем билеты для каждой зоны
-    FOR i IN 1..v_zone_record.capacity LOOP
-      INSERT INTO tickets (
-        event_id, zone_id, seat_id, status, created_at, updated_at
-      ) VALUES (
-        p_event_id, v_zone_record.id, NULL, 'free', NOW(), NOW()
-      );
-      v_tickets_created := v_tickets_created + 1;
+  -- Проверяем наличие индивидуальных мест и при их наличии пропускаем создание зональных билетов
+  SELECT EXISTS (SELECT 1 FROM single_seats WHERE venue_id = v_venue_id)
+    INTO v_has_single_seats;
+
+  IF NOT v_has_single_seats THEN
+    -- Создаем билеты для зон (sections/polygons)
+    FOR v_zone_record IN
+      SELECT id, capacity FROM zones WHERE venue_id = v_venue_id AND capacity > 0
+    LOOP
+      -- Создаем билеты для каждой зоны
+      FOR i IN 1..v_zone_record.capacity LOOP
+        INSERT INTO tickets (
+          event_id, zone_id, seat_id, status, created_at, updated_at
+        ) VALUES (
+          p_event_id, v_zone_record.id, NULL, 'free', NOW(), NOW()
+        );
+        v_tickets_created := v_tickets_created + 1;
+      END LOOP;
+      v_zones_created := v_zones_created + 1;
     END LOOP;
-    v_zones_created := v_zones_created + 1;
-  END LOOP;
+  END IF;
 
   -- Создаем билеты для отдельных мест
   FOR v_seat_record IN 

--- a/migrations/20240918_regenerate_tickets.sql
+++ b/migrations/20240918_regenerate_tickets.sql
@@ -1,0 +1,2 @@
+-- Regenerate tickets for all existing events after updating create_event_tickets
+SELECT create_event_tickets(id) FROM events;


### PR DESCRIPTION
## Summary
- avoid generating zone tickets when a venue already has individual seats
- add migration to regenerate tickets for existing events

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a24499368483229fe3f991e7665a23