### PR TITLE
Remove price display from event card

### DIFF
--- a/src/components/EventCard.jsx
+++ b/src/components/EventCard.jsx
@@ -51,11 +51,6 @@ const EventCard=({event,size="large"})=> {
     navigate(`/event/${event.id}`);
   };
 
-  // Format price with proper decimal places
-  const formatPrice=(price)=> {
-    return price ? Number(price).toFixed(2) : '0.00';
-  };
-
   const accentColor=event?.accent_color || event?.accent || '#f59e0b';
 
   if (size==="large") {
@@ -102,12 +97,9 @@ const EventCard=({event,size="large"})=> {
           </div>
         )}
         
-        <div className="flex justify-between items-center">
+        <div className="flex items-center">
           <span className="text-zinc-500 dark:text-neutral-500 text-xs">
             {formatDate(event.date)} • {event.location}
-          </span>
-          <span className="text-xs font-bold text-zinc-900 dark:text-white">
-            от €{formatPrice(event.price)}
           </span>
         </div>
       </div>
@@ -147,11 +139,8 @@ const EventCard=({event,size="large"})=> {
           </div>
         )}
         
-        <div className="flex justify-between items-center">
+        <div className="flex items-center">
           <span className="text-zinc-500 dark:text-neutral-500 text-xs block truncate">{formatDate(event.date)}</span>
-          <span className="text-xs font-bold text-zinc-900 dark:text-white">
-            от €{formatPrice(event.price)}
-          </span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- drop price formatting and display from EventCard
- show only date and location in both large and compact variants

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a366922b50832287cbf7bbd329c876