### PR TITLE
Remove obsolete address field from EventCard

### DIFF
--- a/src/components/EventCard.jsx
+++ b/src/components/EventCard.jsx
@@ -89,11 +89,6 @@ const EventCard=({event,size="large"})=> {
             <div className="text-[13px] font-medium" style={{color: accentColor}}>
               {event.venue.name}
             </div>
-            {(event.venue.address || event.address) && (
-              <div className="text-[12px] text-gray-500">
-                {event.venue.address || event.address}
-              </div>
-            )}
           </div>
         )}
         
@@ -131,11 +126,6 @@ const EventCard=({event,size="large"})=> {
             <div className="text-[13px] font-medium truncate" style={{color: accentColor}}>
               {event.venue.name}
             </div>
-            {(event.venue.address || event.address) && (
-              <div className="text-[12px] text-gray-500 truncate">
-                {event.venue.address || event.address}
-              </div>
-            )}
           </div>
         )}
         

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -29,7 +29,6 @@ const HomePage=()=> {
             title: event.title,
             location: event.location,
             venue: event.venue,
-            address: event.address,
             accent: event.accent_color || event.accent,
             date: event.event_date ? new Date(event.event_date).toISOString().split('T')[0] : new Date().toISOString().split('T')[0],
             image: event.image || 'https://placehold.co/600x400/333/FFF?text=Event',


### PR DESCRIPTION
## Summary
- drop event address display from EventCard
- trim event address field when preparing data on HomePage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a367fe21388322abf4337e32c1f649