### PR TITLE
Use status field for archiving events

### DIFF
--- a/src/services/eventService.js
+++ b/src/services/eventService.js
@@ -9,6 +9,7 @@ export const fetchEvents = async () => {
     const { data, error } = await supabase
       .from('events')
       .select('*, venue:venues(*)')
+      .neq('status', 'archived')
       .order('event_date', { ascending: true });
 
     if (error) throw error;
@@ -65,6 +66,7 @@ export const fetchEventById = async (eventId) => {
       .from('events')
       .select('*, venue:venues(*)')
       .eq('id', eventId)
+      .neq('status', 'archived')
       .single();
 
     if (error) throw error;
@@ -391,7 +393,7 @@ export const archiveEvent = async (eventId) => {
   try {
     const { error } = await supabase
       .from('events')
-      .update({ archived: true })
+      .update({ status: 'archived' })
       .eq('id', eventId);
 
     if (error) throw error;
@@ -446,10 +448,10 @@ export const deleteEventPartial = async (eventId) => {
 
     if (priceError) throw priceError;
 
-    // Mark event as archived so sold tickets remain linked
+    // Mark event with status 'archived' so sold tickets remain linked
     const { error: eventError } = await supabase
       .from('events')
-      .update({ archived: true })
+      .update({ status: 'archived' })
       .eq('id', eventId);
 
     if (eventError) throw eventError;

--- a/src/services/eventService.test.js
+++ b/src/services/eventService.test.js
@@ -11,7 +11,11 @@ test('fetchEventById returns event with prices', async (t) => {
             return {
               eq() {
                 return {
-                  single: async () => ({ data: { id: 1, title: 'Concert', venue: {} }, error: null })
+                  neq() {
+                    return {
+                      single: async () => ({ data: { id: 1, title: 'Concert', venue: {} }, error: null })
+                    };
+                  }
                 };
               }
             };
@@ -67,6 +71,13 @@ test('fetchEvents resolves image URLs', async (t) => {
             return {
               order() {
                 return Promise.resolve({ data: events, error: null });
+              },
+              neq() {
+                return {
+                  order() {
+                    return Promise.resolve({ data: events, error: null });
+                  }
+                };
               }
             };
           }


### PR DESCRIPTION
## Summary
- replace archived flag with `status: 'archived'` in event service
- filter archived events from fetching operations
- adjust tests for new status-based archiving

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a39cc1dd688322a5a0c4aa2b3c8293