### PR TITLE
Add option to include archived events in fetchEvents

### DIFF
--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -527,7 +527,7 @@ const AdminPage = () => {
   const loadEvents = async () => {
     try {
       setLoading(true);
-      const eventsData = await fetchEvents();
+      const eventsData = await fetchEvents(true);
       setEvents(eventsData || []);
     } catch (error) {
       console.error('Error loading events:', error);

--- a/src/services/eventService.js
+++ b/src/services/eventService.js
@@ -4,13 +4,17 @@ import {createEventTickets} from './ticketService';
 const isDevelopment = (import.meta.env?.MODE || process.env.NODE_ENV) !== 'production';
 
 // Fetch all events
-export const fetchEvents = async () => {
+export const fetchEvents = async (includeArchived = false) => {
   try {
-    const { data, error } = await supabase
+    let query = supabase
       .from('events')
-      .select('*, venue:venues(*)')
-      .neq('status', 'archived')
-      .order('event_date', { ascending: true });
+      .select('*, venue:venues(*)');
+
+    if (!includeArchived) {
+      query = query.neq('status', 'archived');
+    }
+
+    const { data, error } = await query.order('event_date', { ascending: true });
 
     if (error) throw error;
 


### PR DESCRIPTION
## Summary
- allow fetchEvents to optionally include archived records
- load admin events with includeArchived flag

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3a12ae2b48322a0a44771efe24651