### PR TITLE
Adjust delete action to update event status

### DIFF
--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -1232,16 +1232,31 @@ const AdminPage = () => {
     if (!eventToDelete) return;
     try {
       setDeleting(eventToDelete);
-      let success = false;
       if (action === 'archive') {
-        success = await archiveEvent(eventToDelete);
+        const success = await archiveEvent(eventToDelete);
+        if (success !== false) {
+          setEvents((prev) =>
+            prev.map(event =>
+              event.id === eventToDelete ? { ...event, status: 'archived' } : event
+            )
+          );
+          await loadEvents();
+        }
       } else if (action === 'partial') {
-        success = await deleteEventPartial(eventToDelete);
+        const success = await deleteEventPartial(eventToDelete);
+        if (success !== false) {
+          setEvents((prev) =>
+            prev.map(event =>
+              event.id === eventToDelete ? { ...event, status: 'archived' } : event
+            )
+          );
+          await loadEvents();
+        }
       } else if (action === 'cascade') {
-        success = await deleteEventCascade(eventToDelete);
-      }
-      if (success !== false) {
-        setEvents(events.filter(event => event.id !== eventToDelete));
+        const success = await deleteEventCascade(eventToDelete);
+        if (success !== false) {
+          setEvents((prev) => prev.filter(event => event.id !== eventToDelete));
+        }
       }
     } catch (error) {
       console.error('Error deleting event:', error);


### PR DESCRIPTION
## Summary
- Update `handleDeleteAction` to update event status for archive/partial deletions
- Keep cascade deletion behavior and refresh events list after status changes

## Testing
- `npm test` (fails: Invalid URL)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3a21eb1c8832281f89fe3202760c0