### PR TITLE
feat(admin): show event status and allow unarchiving

### DIFF
--- a/src/services/eventService.js
+++ b/src/services/eventService.js
@@ -409,6 +409,23 @@ export const archiveEvent = async (eventId) => {
   }
 };
 
+// Unarchive event
+export const unarchiveEvent = async (eventId) => {
+  try {
+    const { error } = await supabase
+      .from('events')
+      .update({ status: 'published' })
+      .eq('id', eventId);
+
+    if (error) throw error;
+
+    return true;
+  } catch (error) {
+    console.error('Error unarchiving event:', error);
+    throw error;
+  }
+};
+
 // Check if event has linked order items (sold tickets)
 const hasEventOrderItems = async (eventId) => {
   try {


### PR DESCRIPTION
## Summary
- show event status in admin table
- restore archived events via new unarchive button
- map event statuses to user-friendly labels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3a3aecc9083229a0100e2f585fbeb