### PR TITLE
feat: support partial event status for archived events

### DIFF
--- a/migrations/20240921_soft_delete_support.sql
+++ b/migrations/20240921_soft_delete_support.sql
@@ -1,7 +1,7 @@
 -- Add status column to events
 ALTER TABLE events
   ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'draft'
-  CHECK (status IN ('draft','published','archived'));
+  CHECK (status IN ('draft','published','archived','partial'));
 
 -- Add archived_at columns for soft delete support
 ALTER TABLE tickets ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ;

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -1232,6 +1232,10 @@ const AdminPage = () => {
     setShowEventWizard(true);
   };
 
+  const handleViewEvent = (eventId) => {
+    navigate(`/event/${eventId}`);
+  };
+
   const handleDeleteEvent = (eventId) => {
     setEventToDelete(eventId);
     setShowDeleteModal(true);
@@ -1256,7 +1260,7 @@ const AdminPage = () => {
         if (success !== false) {
           setEvents((prev) =>
             prev.map(event =>
-              event.id === eventToDelete ? { ...event, status: 'archived' } : event
+              event.id === eventToDelete ? { ...event, status: 'partial' } : event
             )
           );
           await loadEvents();
@@ -1758,6 +1762,14 @@ const AdminPage = () => {
                                 title="Вернуть"
                               >
                                 <SafeIcon icon={FiRotateCcw} />
+                              </button>
+                            ) : event.status === 'partial' ? (
+                              <button
+                                onClick={() => handleViewEvent(event.id)}
+                                className="p-2 text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-white transition"
+                                title="Просмотр"
+                              >
+                                <SafeIcon icon={FiEye} />
                               </button>
                             ) : (
                               <>

--- a/src/services/eventService.js
+++ b/src/services/eventService.js
@@ -447,11 +447,6 @@ const hasEventOrderItems = async (eventId) => {
 // Delete event but keep sold tickets
 export const deleteEventPartial = async (eventId) => {
   try {
-    // Check if event has sold tickets
-    if (await hasEventOrderItems(eventId)) {
-      throw new Error('Невозможно удалить проданные билеты');
-    }
-
     // Remove all tickets that are not sold
     const { error: ticketsError } = await supabase
       .from('tickets')
@@ -469,10 +464,10 @@ export const deleteEventPartial = async (eventId) => {
 
     if (priceError) throw priceError;
 
-    // Mark event with status 'archived' so sold tickets remain linked
+    // Mark event with status 'partial' so sold tickets remain linked
     const { error: eventError } = await supabase
       .from('events')
-      .update({ status: 'archived' })
+      .update({ status: 'partial' })
       .eq('id', eventId);
 
     if (eventError) throw eventError;


### PR DESCRIPTION
## Summary
- allow `events.status` to accept `partial`
- mark partially deleted events with `status: 'partial'`
- show sold events in admin with read-only view option

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3a583e6c88322bd4f17c1d51d2e57