### PR TITLE
Add seat status overview component to EventDashboard

### DIFF
--- a/src/components/admin/EventDashboard/SeatStatusManager.jsx
+++ b/src/components/admin/EventDashboard/SeatStatusManager.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+const SeatStatusManager = ({ statistics }) => {
+  const total = statistics?.totalSeats || 0;
+  const sold = statistics?.soldSeats || 0;
+  const held = statistics?.heldSeats || 0;
+  const available = statistics?.freeSeats || 0;
+
+  const getPercentage = (value) => (total ? (value / total) * 100 : 0);
+
+  return (
+    <div className="bg-zinc-100 dark:bg-zinc-800 p-4 rounded-lg">
+      <h3 className="text-sm font-medium mb-4">Seat Status Overview</h3>
+      <div className="space-y-4">
+        <div>
+          <div className="flex justify-between mb-1 text-sm">
+            <span>Sold</span>
+            <span>{sold}/{total}</span>
+          </div>
+          <div className="w-full bg-gray-200 dark:bg-gray-700 rounded h-4">
+            <div
+              className="h-4 rounded bg-green-500"
+              style={{ width: `${getPercentage(sold)}%` }}
+            />
+          </div>
+        </div>
+        <div>
+          <div className="flex justify-between mb-1 text-sm">
+            <span>Held</span>
+            <span>{held}/{total}</span>
+          </div>
+          <div className="w-full bg-gray-200 dark:bg-gray-700 rounded h-4">
+            <div
+              className="h-4 rounded bg-yellow-500"
+              style={{ width: `${getPercentage(held)}%` }}
+            />
+          </div>
+        </div>
+        <div>
+          <div className="flex justify-between mb-1 text-sm">
+            <span>Available</span>
+            <span>{available}/{total}</span>
+          </div>
+          <div className="w-full bg-gray-200 dark:bg-gray-700 rounded h-4">
+            <div
+              className="h-4 rounded bg-gray-500"
+              style={{ width: `${getPercentage(available)}%` }}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SeatStatusManager;

--- a/src/components/admin/EventDashboard/index.jsx
+++ b/src/components/admin/EventDashboard/index.jsx
@@ -30,7 +30,6 @@ const EventDashboard = () => {
   const [statistics, setStatistics] = useState(null);
   const [loading, setLoading] = useState(true);
   const [showPricingModal, setShowPricingModal] = useState(false);
-  const [showSeatManager, setShowSeatManager] = useState(false);
   const [realtimeStatus, setRealtimeStatus] = useState(false);
   const [regeneratingSeats, setRegeneratingSeats] = useState(false);
 
@@ -196,12 +195,6 @@ const EventDashboard = () => {
             Edit Prices
           </button>
           <button
-            onClick={() => setShowSeatManager(true)}
-            className="px-4 py-2 bg-indigo-600 text-white rounded"
-          >
-            Manage Seats
-          </button>
-          <button
             onClick={handleRegenerateSeats}
             disabled={regeneratingSeats}
             className="flex items-center px-4 py-2 bg-zinc-200 dark:bg-zinc-700 text-zinc-800 dark:text-zinc-200 rounded"
@@ -220,15 +213,9 @@ const EventDashboard = () => {
             {realtimeStatus ? 'Connected' : 'Disconnected'}
           </p>
         </div>
-      </div>
 
-      {showSeatManager && (
-        <SeatStatusManager
-          event={event}
-          statistics={statistics}
-          onClose={() => setShowSeatManager(false)}
-        />
-      )}
+        <SeatStatusManager statistics={statistics} />
+      </div>
 
       {showPricingModal && (
         <PricingModal


### PR DESCRIPTION
## Summary
- add SeatStatusManager for visualizing sold, held and available seats
- render seat status overview directly on EventDashboard

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3b06eef088322b814be0a902fb608