### PR TITLE
fix: use explicit order item relation

### DIFF
--- a/src/services/eventService.js
+++ b/src/services/eventService.js
@@ -518,7 +518,7 @@ export const getEventStatistics = async (eventId) => {
       .from(TICKETS_TABLE)
       .select(`
         status,
-        order_item:${ORDER_ITEMS_TABLE}(
+        order_item:${ORDER_ITEMS_TABLE}!tickets_order_item_id_fkey(
           unit_price,
           order:orders(created_at)
         )


### PR DESCRIPTION
## Summary
- ensure getEventStatistics uses explicit tickets→order_items foreign key

## Testing
- `node - <<'NODE' ...` (validated query uses tickets_order_item_id_fkey)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3bcea77a8832286c620178fb8c192