### PR TITLE
Handle partial event deletion with reserved tickets

### DIFF
--- a/src/services/eventService.js
+++ b/src/services/eventService.js
@@ -457,24 +457,24 @@ export const deleteEventPartial = async (eventId) => {
       .from('tickets')
       .delete()
       .eq('event_id', eventId)
-      .neq('status', 'sold');
+      .neq('status', 'sold')
+      .is('order_item_id', null);
 
     if (ticketsError) throw ticketsError;
 
-    // Get event price IDs linked to sold tickets
-    const { data: soldPriceRefs, error: soldPriceError } = await supabase
+    // Get event price IDs linked to remaining tickets
+    const { data: ticketRefs, error: ticketRefError } = await supabase
       .from('tickets')
       .select('event_price_id')
-      .eq('event_id', eventId)
-      .eq('status', 'sold');
+      .eq('event_id', eventId);
 
-    if (soldPriceError) throw soldPriceError;
+    if (ticketRefError) throw ticketRefError;
 
-    const priceIdsToKeep = (soldPriceRefs || [])
+    const priceIdsToKeep = (ticketRefs || [])
       .map(ticket => ticket.event_price_id)
       .filter(Boolean);
 
-    // Remove event prices that are not referenced by sold tickets
+    // Remove event prices that are not referenced by remaining tickets
     let priceDeleteQuery = supabase
       .from('event_prices')
       .delete()

--- a/src/services/eventService.test.js
+++ b/src/services/eventService.test.js
@@ -203,3 +203,100 @@ test('deleteEventCascade allows force deletion with sold tickets', async (t) => 
   delete global.__mockSupabase;
   delete global.__mockTicketService;
 });
+
+test('deleteEventPartial keeps prices for sold and reserved tickets', async (t) => {
+  const mockSupabase = {
+    from(table) {
+      if (table === 'tickets') {
+        return {
+          delete() {
+            return {
+              eq(column, id) {
+                assert.equal(column, 'event_id');
+                assert.equal(id, 1);
+                return {
+                  neq(col, val) {
+                    assert.equal(col, 'status');
+                    assert.equal(val, 'sold');
+                    return {
+                      is(col2, val2) {
+                        assert.equal(col2, 'order_item_id');
+                        assert.equal(val2, null);
+                        return Promise.resolve({ error: null });
+                      }
+                    };
+                  }
+                };
+              }
+            };
+          },
+          select() {
+            return {
+              eq(column, id) {
+                assert.equal(column, 'event_id');
+                assert.equal(id, 1);
+                return Promise.resolve({
+                  data: [
+                    { event_price_id: 1 },
+                    { event_price_id: 2 }
+                  ],
+                  error: null
+                });
+              }
+            };
+          }
+        };
+      }
+      if (table === 'event_prices') {
+        return {
+          delete() {
+            return {
+              eq(column, id) {
+                assert.equal(column, 'event_id');
+                assert.equal(id, 1);
+                return {
+                  not(col, operator, list) {
+                    assert.equal(col, 'id');
+                    assert.equal(operator, 'in');
+                    assert.equal(list, '(1,2)');
+                    return Promise.resolve({ error: null });
+                  }
+                };
+              }
+            };
+          }
+        };
+      }
+      if (table === 'events') {
+        return {
+          update() {
+            return {
+              eq(column, id) {
+                assert.equal(column, 'id');
+                assert.equal(id, 1);
+                return Promise.resolve({ error: null });
+              }
+            };
+          }
+        };
+      }
+      return {};
+    }
+  };
+
+  global.__mockSupabase = mockSupabase;
+  global.__mockTicketService = { createEventTickets: async () => ({}) };
+  const code = await fs.readFile(new URL('./eventService.js', import.meta.url), 'utf8');
+  const patched = code
+    .replace("import supabase from '../lib/supabase';", 'const supabase = global.__mockSupabase;')
+    .replace("import {createEventTickets} from './ticketService';", 'const {createEventTickets} = global.__mockTicketService;');
+  const { deleteEventPartial } = await import(
+    `data:text/javascript;base64,${Buffer.from(patched).toString('base64')}?partial`
+  );
+
+  const result = await deleteEventPartial(1);
+  assert.equal(result, true);
+
+  delete global.__mockSupabase;
+  delete global.__mockTicketService;
+});


### PR DESCRIPTION
## Summary
- Avoid deleting tickets tied to orders and track remaining ticket price references in `deleteEventPartial`
- Remove only orphaned `event_prices` entries and add coverage for mixed sold/reserved scenarios

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4810d33ec832284ebf1c0ca7f674f