### PR TITLE
Add SQL error fallback for event deletion

### DIFF
--- a/src/services/eventService.js
+++ b/src/services/eventService.js
@@ -490,10 +490,11 @@ export const deleteEventCascade = async (eventId, force = false) => {
       if (
         error.code === 'PGRST202' ||
         error.code === 'PGRST100' ||
+        error.code?.startsWith('42') || // SQL-level failures like 42702
         error.message?.includes('delete_event_cascade')
       ) {
         console.warn(
-          'delete_event_cascade function missing. Falling back to manual deletion.',
+          'delete_event_cascade RPC failed. Falling back to manual deletion.',
           error
         );
 


### PR DESCRIPTION
## Summary
- ensure `deleteEventCascade` falls back to manual deletion when RPC fails with SQL errors like `42702`
- log a clearer message when the RPC fallback is used

## Testing
- `npm run lint`
- `npm test` *(fails: Invalid URL)*

------
https://chatgpt.com/codex/tasks/task_e_68a498c265088322a24aaf4ab0710de0